### PR TITLE
Fix header and sidebar role lookup

### DIFF
--- a/component/sidebar.php
+++ b/component/sidebar.php
@@ -18,15 +18,17 @@ $active = basename($_SERVER['SCRIPT_NAME'] ?? '');
 $userId = (int)($_SESSION['user_id'] ?? 0);
 $role = 'user';
 
-try {
-    $stmt = $pdo->prepare('SELECT r.name FROM users u JOIN roles r ON u.role_id = r.id WHERE u.id = :id LIMIT 1');
-    $stmt->execute(['id' => $userId]);
-    $dbRole = $stmt->fetchColumn();
-    if (is_string($dbRole) && $dbRole !== '') {
-        $role = $dbRole;
+if ($userId > 0) {
+    try {
+        $stmt = $pdo->prepare('SELECT r.name FROM user_roles ur JOIN roles r ON ur.role_id = r.id WHERE ur.user_id = :id LIMIT 1');
+        $stmt->execute(['id' => $userId]);
+        $dbRole = $stmt->fetchColumn();
+        if (is_string($dbRole) && $dbRole !== '') {
+            $role = $dbRole;
+        }
+    } catch (Throwable $e) {
+        $role = 'user';
     }
-} catch (Throwable $e) {
-    $role = 'user';
 }
 
 $orderPath = file_exists(__DIR__ . '/../public/order.php') ? '../public/order.php' : '../public/orders.php';


### PR DESCRIPTION
## Summary
- prevent duplicate session_start warnings in the shared header
- read user roles via the user_roles table and fall back gracefully when no user is logged in
- align header name lookup with firstname/surname columns and reuse the same role lookup in the sidebar

## Testing
- php -l component/header.php
- php -l component/sidebar.php

------
https://chatgpt.com/codex/tasks/task_e_68d3d54aaa4c83289f5b8790cd5f17bc