### PR TITLE
Include flash toast partial across pages

### DIFF
--- a/index.php
+++ b/index.php
@@ -101,6 +101,10 @@ if (!empty($_SESSION['user_id'])) {
 </head>
 
 <body>
+    <?php
+    // Flash mesajlar için toast bileşeni (partials/flash.php dahil edildi)
+    require_once __DIR__ . '/partials/flash.php';
+    ?>
 
     <div class="row w-100">
         <!-- Sol kutu -->

--- a/public/auth/login.php
+++ b/public/auth/login.php
@@ -455,6 +455,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 
 <body>
+    <?php
+    // Flash mesajlar için toast bileşeni (partials/flash.php dahil edildi)
+    require_once __DIR__ . '/../../partials/flash.php';
+    ?>
     <main class="page">
         <section class="shell">
             <div class="hero">

--- a/public/auth/register.php
+++ b/public/auth/register.php
@@ -211,6 +211,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 
 <body>
+    <?php
+    // Flash mesajlar için toast bileşeni (partials/flash.php dahil edildi)
+    require_once __DIR__ . '/../../partials/flash.php';
+    ?>
     <main class="page">
         <section class="shell">
             <div class="hero"><span class="logo">NEXA</span></div>

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -177,6 +177,10 @@ function formatOrderDate(?string $date): string
     </style>
 </head>
 <body data-powered-by="Claude Code">
+    <?php
+    // Flash mesajlar için toast bileşeni (partials/flash.php dahil edildi)
+    require_once __DIR__ . '/../partials/flash.php';
+    ?>
     <?php require_once __DIR__ . '/../component/header.php'; ?>
     <div class="d-flex">
         <?php require_once __DIR__ . '/../component/sidebar.php'; ?>


### PR DESCRIPTION
## Summary
- include the shared flash toast partial at the top of each main page body so session flash messages display consistently
- add inline comments noting the inclusion of the flash toast component for maintainability

## Testing
- php -l index.php
- php -l public/auth/login.php
- php -l public/auth/register.php
- php -l public/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68d3dcc0e9308328988dced4ce21ec10