### PR TITLE
Add notifications table schema and constraints

### DIFF
--- a/campro.sql
+++ b/campro.sql
@@ -99,6 +99,27 @@ CREATE TABLE IF NOT EXISTS `user_roles` (
   KEY `fk_ur_role` (`role_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
 
+-- --------------------------------------------------------
+
+--
+-- Tablo için tablo yapısı `notifications`
+--
+
+DROP TABLE IF EXISTS `notifications`;
+CREATE TABLE IF NOT EXISTS `notifications` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `user_id` int NOT NULL,
+  `title` varchar(150) COLLATE utf8mb4_turkish_ci NOT NULL,
+  `message` text COLLATE utf8mb4_turkish_ci NOT NULL,
+  `category` varchar(50) COLLATE utf8mb4_turkish_ci DEFAULT NULL,
+  `is_read` tinyint(1) NOT NULL DEFAULT '0',
+  `read_at` datetime DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `idx_notifications_user_read` (`user_id`,`is_read`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_turkish_ci;
+
 --
 -- Dökümü yapılmış tablolar için kısıtlamalar
 --
@@ -116,6 +137,13 @@ ALTER TABLE `role_permissions`
 ALTER TABLE `user_roles`
   ADD CONSTRAINT `fk_ur_role` FOREIGN KEY (`role_id`) REFERENCES `roles` (`id`) ON DELETE CASCADE,
   ADD CONSTRAINT `fk_ur_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE;
+
+--
+-- Tablo kısıtlamaları `notifications`
+--
+ALTER TABLE `notifications`
+  ADD CONSTRAINT `fk_notifications_user`
+    FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE;
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;


### PR DESCRIPTION
## Summary
- add the notifications table definition with indexes and timestamps
- link notifications to users via a foreign key constraint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d643479f6083288286833b182fcc51