### PR TITLE
Add shared brand palette and apply across pages

### DIFF
--- a/assets/css/root.css
+++ b/assets/css/root.css
@@ -1,0 +1,70 @@
+/**
+ * Nexa global brand tokens.
+ * Centralizes the color palette used across the application so that
+ * components share a consistent visual identity.
+ */
+:root {
+    --brand-primary: #667eea;
+    --brand-primary-dark: #764ba2;
+    --brand-secondary: #f093fb;
+    --brand-secondary-dark: #f5576c;
+    --brand-surface: #f8fafc;
+    --brand-surface-strong: #ffffff;
+    --brand-surface-hover: #f1f5f9;
+    --brand-border: #e5e7eb;
+    --brand-ink: #1a1a1a;
+    --brand-ink-light: #374151;
+    --brand-ink-lighter: #6b7280;
+    --brand-ink-lightest: #9ca3af;
+    --brand-accent-blue: #3b82f6;
+    --brand-accent-purple: #8b5cf6;
+    --brand-success: #10b981;
+    --brand-danger: #ef4444;
+    --brand-warning: #f59e0b;
+    --brand-info: #06b6d4;
+
+    --primary-gradient: linear-gradient(135deg, var(--brand-primary) 0%, var(--brand-primary-dark) 100%);
+    --secondary-gradient: linear-gradient(135deg, var(--brand-secondary) 0%, var(--brand-secondary-dark) 100%);
+
+    --sidebar-bg: var(--brand-surface-strong);
+    --sidebar-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+
+    --surface: var(--brand-surface-strong);
+    --surface-elevated: var(--brand-surface-strong);
+    --surface-hover: var(--brand-surface-hover);
+    --border: var(--brand-border);
+    --border-light: var(--brand-border);
+
+    --ink: var(--brand-ink);
+    --ink-light: var(--brand-ink-light);
+    --ink-lighter: var(--brand-ink-lighter);
+    --ink-lightest: var(--brand-ink-lightest);
+    --ink-secondary: var(--brand-ink-lighter);
+    --muted: var(--brand-ink-lighter);
+    --line: var(--brand-border);
+
+    --radius: 12px;
+    --radius-lg: 16px;
+
+    --shadow-sm: 0 1px 2px 0 rgba(15, 23, 42, 0.08);
+    --shadow-md: 0 4px 6px -1px rgba(15, 23, 42, 0.1), 0 2px 4px -1px rgba(15, 23, 42, 0.06);
+    --shadow-lg: 0 10px 15px -3px rgba(15, 23, 42, 0.1), 0 4px 6px -2px rgba(15, 23, 42, 0.08);
+    --shadow-xl: 0 20px 25px -5px rgba(15, 23, 42, 0.1), 0 10px 10px -5px rgba(15, 23, 42, 0.06);
+
+    --nexa-primary: var(--brand-primary);
+    --nexa-primary-dark: var(--brand-primary-dark);
+    --nexa-secondary: var(--brand-ink-lighter);
+    --nexa-success: var(--brand-success);
+    --nexa-warning: var(--brand-warning);
+    --nexa-danger: var(--brand-danger);
+    --nexa-info: var(--brand-info);
+    --nexa-bg-light: var(--brand-surface);
+    --nexa-bg-white: var(--brand-surface-strong);
+    --nexa-border: var(--brand-border);
+    --nexa-text-primary: var(--brand-ink);
+    --nexa-text-secondary: var(--brand-ink-lighter);
+    --nexa-shadow-sm: var(--shadow-sm);
+    --nexa-shadow: var(--shadow-md);
+    --nexa-shadow-lg: var(--shadow-lg);
+    --nexa-shadow-xl: var(--shadow-xl);
+}

--- a/assets/css/root.css
+++ b/assets/css/root.css
@@ -4,36 +4,42 @@
  * components share a consistent visual identity.
  */
 :root {
-    --brand-primary: #667eea;
-    --brand-primary-dark: #764ba2;
-    --brand-secondary: #f093fb;
-    --brand-secondary-dark: #f5576c;
-    --brand-surface: #f8fafc;
+    --brand-primary: #1f6feb;
+    --brand-primary-dark: #1546a0;
+    --brand-primary-darker: #0f2d6f;
+    --brand-primary-light: #4c8dff;
+    --brand-primary-lighter: #7aa4ff;
+    --brand-primary-soft: #cddcff;
+    --brand-primary-subtle: #eef3ff;
+
+    --brand-secondary: var(--brand-primary-light);
+    --brand-secondary-dark: var(--brand-primary);
+    --brand-surface: #f7f9ff;
     --brand-surface-strong: #ffffff;
-    --brand-surface-hover: #f1f5f9;
-    --brand-border: #e5e7eb;
-    --brand-ink: #1a1a1a;
-    --brand-ink-light: #374151;
-    --brand-ink-lighter: #6b7280;
-    --brand-ink-lightest: #9ca3af;
-    --brand-accent-blue: #3b82f6;
-    --brand-accent-purple: #8b5cf6;
-    --brand-success: #10b981;
-    --brand-danger: #ef4444;
-    --brand-warning: #f59e0b;
-    --brand-info: #06b6d4;
+    --brand-surface-hover: #eef3ff;
+    --brand-border: #d5e2ff;
+    --brand-ink: #0b1d3a;
+    --brand-ink-light: #1f3b66;
+    --brand-ink-lighter: #4a5f8f;
+    --brand-ink-lightest: #7c8eb0;
+    --brand-accent-blue: var(--brand-primary);
+    --brand-accent-purple: var(--brand-primary-dark);
+    --brand-success: var(--brand-primary-light);
+    --brand-danger: var(--brand-primary-dark);
+    --brand-warning: var(--brand-primary-lighter);
+    --brand-info: var(--brand-primary);
 
     --primary-gradient: linear-gradient(135deg, var(--brand-primary) 0%, var(--brand-primary-dark) 100%);
-    --secondary-gradient: linear-gradient(135deg, var(--brand-secondary) 0%, var(--brand-secondary-dark) 100%);
+    --secondary-gradient: linear-gradient(135deg, var(--brand-primary-light) 0%, var(--brand-primary) 100%);
 
-    --sidebar-bg: var(--brand-surface-strong);
-    --sidebar-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+    --sidebar-bg: color-mix(in srgb, var(--brand-primary-subtle) 90%, white);
+    --sidebar-shadow: 0 8px 32px rgba(15, 23, 42, 0.12);
 
     --surface: var(--brand-surface-strong);
     --surface-elevated: var(--brand-surface-strong);
     --surface-hover: var(--brand-surface-hover);
     --border: var(--brand-border);
-    --border-light: var(--brand-border);
+    --border-light: color-mix(in srgb, var(--brand-border) 60%, transparent);
 
     --ink: var(--brand-ink);
     --ink-light: var(--brand-ink-light);
@@ -46,19 +52,19 @@
     --radius: 12px;
     --radius-lg: 16px;
 
-    --shadow-sm: 0 1px 2px 0 rgba(15, 23, 42, 0.08);
-    --shadow-md: 0 4px 6px -1px rgba(15, 23, 42, 0.1), 0 2px 4px -1px rgba(15, 23, 42, 0.06);
-    --shadow-lg: 0 10px 15px -3px rgba(15, 23, 42, 0.1), 0 4px 6px -2px rgba(15, 23, 42, 0.08);
-    --shadow-xl: 0 20px 25px -5px rgba(15, 23, 42, 0.1), 0 10px 10px -5px rgba(15, 23, 42, 0.06);
+    --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.08);
+    --shadow-md: 0 4px 8px rgba(15, 23, 42, 0.08);
+    --shadow-lg: 0 16px 32px rgba(15, 23, 42, 0.1);
+    --shadow-xl: 0 24px 48px rgba(15, 23, 42, 0.12);
 
     --nexa-primary: var(--brand-primary);
     --nexa-primary-dark: var(--brand-primary-dark);
-    --nexa-secondary: var(--brand-ink-lighter);
-    --nexa-success: var(--brand-success);
-    --nexa-warning: var(--brand-warning);
-    --nexa-danger: var(--brand-danger);
-    --nexa-info: var(--brand-info);
-    --nexa-bg-light: var(--brand-surface);
+    --nexa-secondary: var(--brand-primary-light);
+    --nexa-success: var(--brand-primary-light);
+    --nexa-warning: var(--brand-primary-lighter);
+    --nexa-danger: var(--brand-primary-dark);
+    --nexa-info: var(--brand-primary);
+    --nexa-bg-light: var(--brand-primary-subtle);
     --nexa-bg-white: var(--brand-surface-strong);
     --nexa-border: var(--brand-border);
     --nexa-text-primary: var(--brand-ink);

--- a/component/sidebar.php
+++ b/component/sidebar.php
@@ -373,7 +373,11 @@ $renderMenu = static function (array $menuItems, string $active, string $request
     .sidebar-header {
         padding: 0.5rem 0.75rem;
         border-bottom: 1px solid var(--border);
-        background: linear-gradient(135deg, rgba(102, 126, 234, 0.1), rgba(118, 75, 162, 0.1));
+        background: linear-gradient(
+            135deg,
+            color-mix(in srgb, var(--brand-primary) 12%, transparent),
+            color-mix(in srgb, var(--brand-primary-dark) 12%, transparent)
+        );
         position: relative;
     }
 
@@ -384,7 +388,12 @@ $renderMenu = static function (array $menuItems, string $active, string $request
         left: 0;
         right: 0;
         height: 1px;
-        background: linear-gradient(90deg, transparent, rgba(102, 126, 234, 0.5), transparent);
+        background: linear-gradient(
+            90deg,
+            transparent,
+            color-mix(in srgb, var(--brand-primary) 35%, transparent),
+            transparent
+        );
     }
 
     .sidebar-logo {
@@ -475,7 +484,12 @@ $renderMenu = static function (array $menuItems, string $active, string $request
         left: -100%;
         width: 100%;
         height: 100%;
-        background: linear-gradient(90deg, transparent, rgba(102, 126, 234, 0.1), transparent);
+        background: linear-gradient(
+            90deg,
+            transparent,
+            color-mix(in srgb, var(--brand-primary) 16%, transparent),
+            transparent
+        );
         transition: left 0.5s ease;
     }
 
@@ -522,9 +536,9 @@ $renderMenu = static function (array $menuItems, string $active, string $request
     }
 
     .nav-item.has-children.is-active .submenu-toggle {
-        color: var(--accent-purple);
-        border-color: rgba(102, 126, 234, 0.3);
-        background: rgba(102, 126, 234, 0.08);
+        color: var(--brand-primary);
+        border-color: color-mix(in srgb, var(--brand-primary) 35%, transparent);
+        background: color-mix(in srgb, var(--brand-primary) 12%, transparent);
     }
 
     .nav-item.has-children .submenu-toggle .bi {
@@ -578,7 +592,7 @@ $renderMenu = static function (array $menuItems, string $active, string $request
 
     .submenu-indicator {
         font-size: 1.25rem;
-        color: var(--accent-purple);
+        color: var(--brand-primary);
     }
 
     .sidebar .nav-link.active {
@@ -646,8 +660,8 @@ $renderMenu = static function (array $menuItems, string $active, string $request
         width: 40px;
         height: 40px;
         border-radius: 999px;
-        background: rgba(99, 102, 241, 0.12);
-        color: rgba(79, 70, 229, 1);
+        background: color-mix(in srgb, var(--brand-primary) 14%, transparent);
+        color: var(--brand-primary-dark);
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -779,7 +793,11 @@ $renderMenu = static function (array $menuItems, string $active, string $request
 
     .offcanvas-header {
         border-bottom: 1px solid var(--border);
-        background: linear-gradient(135deg, rgba(102, 126, 234, 0.1), rgba(118, 75, 162, 0.1));
+        background: linear-gradient(
+            135deg,
+            color-mix(in srgb, var(--brand-primary) 12%, transparent),
+            color-mix(in srgb, var(--brand-primary-dark) 12%, transparent)
+        );
         padding: 2rem 1.5rem 1.5rem;
     }
 

--- a/component/sidebar.php
+++ b/component/sidebar.php
@@ -318,29 +318,13 @@ $renderMenu = static function (array $menuItems, string $active, string $request
     return $html;
 };
 ?>
+<link rel="stylesheet" href="../assets/css/root.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
     :root {
-        --sidebar-bg: #ffffff;
-        --sidebar-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
-        --primary-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-        --secondary-gradient: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-        --ink: #1a1a1a;
-        --ink-light: #374151;
-        --ink-lighter: #6b7280;
-        --ink-lightest: #9ca3af;
-        --surface: #f8fafc;
-        --surface-hover: #f1f5f9;
-        --border: #e5e7eb;
-        --accent-blue: #3b82f6;
-        --accent-purple: #8b5cf6;
-        --success: #10b981;
-        --danger: #ef4444;
-        --radius: 12px;
-        --radius-lg: 16px;
         --transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     }
 
@@ -587,7 +571,7 @@ $renderMenu = static function (array $menuItems, string $active, string $request
     }
 
     .submenu-link.active {
-        background: rgba(102, 126, 234, 0.12);
+        background: color-mix(in srgb, var(--brand-primary) 12%, transparent);
         color: var(--ink);
         font-weight: 600;
     }
@@ -599,14 +583,18 @@ $renderMenu = static function (array $menuItems, string $active, string $request
 
     .sidebar .nav-link.active {
         color: var(--ink);
-        background: linear-gradient(135deg, rgba(102, 126, 234, 0.1), rgba(118, 75, 162, 0.1));
-        border-color: rgba(102, 126, 234, 0.3);
+        background: linear-gradient(
+            135deg,
+            color-mix(in srgb, var(--brand-primary) 12%, transparent),
+            color-mix(in srgb, var(--brand-primary-dark) 12%, transparent)
+        );
+        border-color: color-mix(in srgb, var(--brand-primary) 30%, transparent);
         font-weight: 600;
         transform: translateX(4px);
     }
 
     .sidebar .nav-link.active .nav-icon {
-        color: #667eea;
+        color: var(--brand-primary);
         transform: scale(1.1);
     }
 
@@ -676,7 +664,7 @@ $renderMenu = static function (array $menuItems, string $active, string $request
 
     .account-dropdown .meta .username {
         font-size: 0.75rem;
-        color: var(--muted, #64748b);
+        color: var(--muted);
     }
 
     .account-dropdown .dropdown-menu {
@@ -691,7 +679,7 @@ $renderMenu = static function (array $menuItems, string $active, string $request
     }
 
     .account-dropdown .dropdown-item.text-danger {
-        color: #ef4444 !important;
+        color: var(--brand-danger) !important;
     }
 
     .account-dropdown .dropdown-divider {
@@ -864,8 +852,8 @@ $renderMenu = static function (array $menuItems, string $active, string $request
         width: 8px;
         height: 8px;
         border-radius: 999px;
-        background: #ef4444;
-        box-shadow: 0 0 0 2px #fff;
+        background: var(--brand-danger);
+        box-shadow: 0 0 0 2px var(--brand-surface-strong);
         display: none;
     }
 

--- a/index.php
+++ b/index.php
@@ -14,30 +14,35 @@ if (!empty($_SESSION['user_id'])) {
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Nexa</title>
+    <link rel="stylesheet" href="assets/css/root.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Monoton&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Monoton&display=swap" rel="stylesheet">
     <style>
         body {
-            background: #f8f9fa;
+            background: var(--brand-surface);
             display: flex;
             align-items: center;
             justify-content: center;
             min-height: 100vh;
             font-family: 'Inter', sans-serif;
+            color: var(--ink);
         }
 
         .row.w-100 {
-            max-width: 800px;
-            background: #f8f9fa;
+            max-width: 860px;
+            background: var(--brand-surface);
             margin: 0 auto;
+            border-radius: var(--radius-lg);
+            overflow: hidden;
+            box-shadow: var(--shadow-lg);
         }
 
         .left-box {
-            background: #f8f9fa;
-            color: #212529;
-            padding: 40px 20px;
+            background: var(--primary-gradient);
+            color: #ffffff;
+            padding: 48px 24px;
             display: flex;
             align-items: center;
             justify-content: center;
@@ -48,27 +53,32 @@ if (!empty($_SESSION['user_id'])) {
             font-family: "Monoton", sans-serif;
             font-size: 4rem;
             letter-spacing: 5px;
-            color: #212529;
+            background: var(--secondary-gradient);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            color: transparent;
         }
 
         .right-box {
-            padding: 40px;
+            padding: 48px 40px;
             display: flex;
             flex-direction: column;
             justify-content: center;
-            background: #f8f9fa;
-            /* Sağ kutu da arka plana karışsın */
+            gap: 1.25rem;
+            background: var(--surface);
         }
 
         .right-box h5 {
             font-size: 1.5rem;
             font-weight: 700;
             margin-bottom: .5rem;
-            color: #212529;
+            color: var(--ink);
         }
 
         .right-box p.text-muted {
             margin-bottom: 1.5rem;
+            color: var(--ink-lighter) !important;
         }
 
         .btn-custom {
@@ -79,22 +89,32 @@ if (!empty($_SESSION['user_id'])) {
         }
 
         .btn-dark {
-            background-color: #212529;
+            background: var(--primary-gradient);
             border: none;
+            color: #ffffff;
         }
 
         .btn-outline-dark {
             border-width: 2px;
+            border-color: var(--brand-primary);
+            color: var(--brand-primary);
+        }
+
+        .btn-outline-dark:hover,
+        .btn-outline-dark:focus {
+            background: var(--primary-gradient);
+            color: #ffffff;
+            border-color: transparent;
         }
 
         .terms {
             font-size: 0.8rem;
             margin-top: 20px;
-            color: #6c757d;
+            color: var(--ink-lightest);
         }
 
         .terms a {
-            color: #495057;
+            color: var(--brand-primary);
             text-decoration: underline;
         }
     </style>

--- a/public/auth/login.php
+++ b/public/auth/login.php
@@ -103,7 +103,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         body {
             font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
-            background: linear-gradient(135deg, var(--brand-primary) 0%, var(--brand-primary-dark) 50%, var(--brand-secondary) 100%);
+            background: linear-gradient(135deg, var(--brand-primary-dark), var(--brand-primary));
             background-attachment: fixed;
             color: var(--ink);
             min-height: 100vh;
@@ -121,9 +121,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             width: 100%;
             height: 100%;
             background:
-                radial-gradient(circle at 20% 80%, rgba(120, 119, 198, 0.3) 0%, transparent 50%),
-                radial-gradient(circle at 80% 20%, rgba(255, 119, 198, 0.3) 0%, transparent 50%),
-                radial-gradient(circle at 40% 40%, rgba(120, 219, 255, 0.3) 0%, transparent 50%);
+                radial-gradient(circle at 20% 80%, color-mix(in srgb, var(--brand-primary) 26%, transparent) 0%, transparent 55%),
+                radial-gradient(circle at 80% 20%, color-mix(in srgb, var(--brand-primary-light) 28%, transparent) 0%, transparent 55%),
+                radial-gradient(circle at 40% 40%, color-mix(in srgb, var(--brand-primary-dark) 20%, transparent) 0%, transparent 50%);
             animation: float 20s ease-in-out infinite;
             z-index: -1;
         }
@@ -173,7 +173,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             font-family: "Monoton", sans-serif;
             font-size: 4.5rem;
             letter-spacing: 0.05em;
-            background: linear-gradient(135deg, var(--brand-surface-strong), var(--brand-surface));
+            background: linear-gradient(135deg, color-mix(in srgb, var(--brand-primary-subtle) 70%, white), var(--brand-primary));
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -239,7 +239,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             font-size: 2rem;
             letter-spacing: -0.025em;
             margin-bottom: 8px;
-            background: linear-gradient(135deg, var(--ink), #374151);
+            background: linear-gradient(
+                135deg,
+                color-mix(in srgb, var(--brand-primary-dark) 80%, #000),
+                color-mix(in srgb, var(--brand-primary) 80%, #000)
+            );
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -259,6 +263,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             margin-bottom: 24px;
             font-weight: 500;
             animation: slideIn 0.3s ease-out;
+            background: linear-gradient(
+                135deg,
+                color-mix(in srgb, var(--brand-primary) 12%, #ffffff),
+                color-mix(in srgb, var(--brand-primary) 24%, #ffffff)
+            );
+            color: color-mix(in srgb, var(--brand-primary-dark) 75%, #000);
+            border-left: 4px solid var(--brand-primary);
         }
 
         @keyframes slideIn {
@@ -273,22 +284,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         }
 
-        .alert-success {
-            background: linear-gradient(135deg, #d1fae5, #a7f3d0);
-            color: #065f46;
-            border-left: 4px solid var(--brand-success);
-        }
-
-        .alert-danger {
-            background: linear-gradient(135deg, #fee2e2, #fca5a5);
-            color: #991b1b;
-            border-left: 4px solid var(--brand-danger);
-        }
-
+        .alert-success,
+        .alert-danger,
         .alert-warning {
-            background: linear-gradient(135deg, #fef3c7, #fcd34d);
-            color: #92400e;
-            border-left: 4px solid var(--brand-warning);
+            background: linear-gradient(
+                135deg,
+                color-mix(in srgb, var(--brand-primary) 12%, #ffffff),
+                color-mix(in srgb, var(--brand-primary) 24%, #ffffff)
+            );
+            color: color-mix(in srgb, var(--brand-primary-dark) 75%, #000);
+            border-left: 4px solid var(--brand-primary);
         }
 
         .form-label {

--- a/public/auth/login.php
+++ b/public/auth/login.php
@@ -80,24 +80,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Nexa — Giriş Yap</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/root.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <?php require_once __DIR__ . '/../../assets/fonts/monoton.php'; ?>
     <style>
         :root {
-            --primary-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            --secondary-gradient: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-            --surface: #ffffff;
-            --surface-elevated: #ffffff;
-            --ink: #1a1a1a;
-            --ink-secondary: #6b7280;
+            --surface: var(--brand-surface-strong);
+            --surface-elevated: var(--brand-surface-strong);
+            --ink: var(--brand-ink);
+            --ink-secondary: var(--brand-ink-lighter);
             --border: rgba(255, 255, 255, 0.1);
-            --border-light: #e5e7eb;
-            --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-            --shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+            --border-light: var(--brand-border);
             --radius: 16px;
             --radius-lg: 24px;
         }
@@ -108,7 +103,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         body {
             font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%);
+            background: linear-gradient(135deg, var(--brand-primary) 0%, var(--brand-primary-dark) 50%, var(--brand-secondary) 100%);
             background-attachment: fixed;
             color: var(--ink);
             min-height: 100vh;
@@ -178,7 +173,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             font-family: "Monoton", sans-serif;
             font-size: 4.5rem;
             letter-spacing: 0.05em;
-            background: linear-gradient(135deg, #ffffff, #f8fafc);
+            background: linear-gradient(135deg, var(--brand-surface-strong), var(--brand-surface));
             -webkit-background-clip: text;
             -webkit-text-fill-color: transparent;
             background-clip: text;
@@ -281,19 +276,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         .alert-success {
             background: linear-gradient(135deg, #d1fae5, #a7f3d0);
             color: #065f46;
-            border-left: 4px solid #10b981;
+            border-left: 4px solid var(--brand-success);
         }
 
         .alert-danger {
             background: linear-gradient(135deg, #fee2e2, #fca5a5);
             color: #991b1b;
-            border-left: 4px solid #ef4444;
+            border-left: 4px solid var(--brand-danger);
         }
 
         .alert-warning {
             background: linear-gradient(135deg, #fef3c7, #fcd34d);
             color: #92400e;
-            border-left: 4px solid #f59e0b;
+            border-left: 4px solid var(--brand-warning);
         }
 
         .form-label {
@@ -316,14 +311,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
 
         .form-control:focus {
-            border-color: #667eea;
-            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+            border-color: var(--brand-primary);
+            box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand-primary) 20%, transparent);
             transform: translateY(-2px);
         }
 
         .form-control.is-invalid {
-            border-color: #ef4444;
-            box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1);
+            border-color: var(--brand-danger);
+            box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand-danger) 20%, transparent);
         }
 
         .invalid-feedback {
@@ -349,7 +344,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         .form-check-input:checked {
             background: var(--primary-gradient);
-            border-color: #667eea;
+            border-color: var(--brand-primary);
         }
 
         .form-check-label {
@@ -383,7 +378,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
         .btn-primary:hover {
             transform: translateY(-2px);
-            box-shadow: 0 8px 25px rgba(102, 126, 234, 0.4);
+            box-shadow: 0 8px 25px color-mix(in srgb, var(--brand-primary) 35%, transparent);
         }
 
         .btn-primary:hover::before {
@@ -391,7 +386,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
 
         .btn-primary:focus {
-            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.3);
+            box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand-primary) 30%, transparent);
         }
 
         .login-link {
@@ -402,14 +397,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
 
         .login-link a {
-            color: #667eea;
+            color: var(--brand-primary);
             text-decoration: none;
             font-weight: 600;
             transition: all 0.2s ease;
         }
 
         .login-link a:hover {
-            color: #5a67d8;
+            color: var(--brand-primary-dark);
             text-decoration: underline;
         }
 

--- a/public/auth/register.php
+++ b/public/auth/register.php
@@ -119,18 +119,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Nexa — Kayıt Ol</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../../assets/css/root.css">
     <?php require_once __DIR__ . '/../../assets/fonts/monoton.php'; ?>
     <style>
         :root {
-            --ink: #0f1419;
-            --muted: #536471;
-            --line: #e6e6e6;
+            --ink: var(--brand-ink);
+            --muted: var(--brand-ink-lighter);
+            --line: var(--brand-border);
             --radius: 14px;
         }
 
         body {
             font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-            background: #fff;
+            background: var(--surface);
             color: var(--ink);
         }
 
@@ -157,6 +158,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             font-family: "Monoton", sans-serif;
             font-size: 3rem;
             letter-spacing: 0.05em;
+            background: var(--secondary-gradient);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
         }
 
         .panel {
@@ -181,6 +186,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             justify-content: center;
             align-items: center;
             border: none;
+            background: var(--surface);
+            box-shadow: var(--shadow-lg);
         }
 
         .form-control,
@@ -192,6 +199,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             border-radius: var(--radius);
             padding: .75rem 1rem;
             font-weight: 600;
+            background: var(--primary-gradient);
+            border: none;
+        }
+
+        .btn-dark:hover,
+        .btn-dark:focus {
+            background: var(--secondary-gradient);
+            color: #fff;
         }
 
         @media (max-width:992px) {

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -211,18 +211,18 @@ if (!empty($_GET['flash'])) {
         }
 
         .stat-card.orders-pending {
-            --stat-color: var(--nexa-warning);
-            --stat-color-dark: color-mix(in srgb, var(--nexa-warning) 75%, black);
+            --stat-color: color-mix(in srgb, var(--nexa-primary) 80%, white);
+            --stat-color-dark: var(--nexa-primary);
         }
 
         .stat-card.ship-today {
-            --stat-color: var(--nexa-info);
-            --stat-color-dark: color-mix(in srgb, var(--nexa-info) 75%, black);
+            --stat-color: color-mix(in srgb, var(--nexa-primary) 65%, white);
+            --stat-color-dark: color-mix(in srgb, var(--nexa-primary-dark) 85%, black);
         }
 
         .stat-card.price-catalogue {
-            --stat-color: var(--nexa-success);
-            --stat-color-dark: color-mix(in srgb, var(--nexa-success) 70%, black);
+            --stat-color: color-mix(in srgb, var(--nexa-primary) 55%, white);
+            --stat-color-dark: color-mix(in srgb, var(--nexa-primary) 75%, white);
         }
 
         .stat-card .stat-icon {
@@ -383,12 +383,13 @@ if (!empty($_GET['flash'])) {
         }
 
         .quick-actions .btn-outline-secondary {
-            border-color: var(--nexa-secondary);
-            color: var(--nexa-secondary);
+            border-color: color-mix(in srgb, var(--nexa-primary) 65%, white);
+            color: color-mix(in srgb, var(--nexa-primary) 65%, white);
         }
 
         .quick-actions .btn-outline-secondary:hover {
-            background: var(--nexa-secondary);
+            background: color-mix(in srgb, var(--nexa-primary) 65%, white);
+            color: white;
             transform: translateY(-2px);
             box-shadow: var(--nexa-shadow);
         }
@@ -425,7 +426,15 @@ if (!empty($_GET['flash'])) {
             transform: translateY(-1px);
         }
 
+        .btn-outline-secondary {
+            border-color: color-mix(in srgb, var(--nexa-primary) 65%, white);
+            color: color-mix(in srgb, var(--nexa-primary) 65%, white);
+        }
+
         .btn-outline-secondary:hover {
+            background: color-mix(in srgb, var(--nexa-primary) 65%, white);
+            border-color: color-mix(in srgb, var(--nexa-primary) 65%, white);
+            color: white;
             transform: translateY(-1px);
         }
 

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -100,38 +100,20 @@ if (!empty($_GET['flash'])) {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Nexa — Yönetim Paneli</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="../assets/css/root.css">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <?php require_once __DIR__ . '/../assets/fonts/monoton.php'; ?>
     <style>
-        :root {
-            --nexa-primary: #2563eb;
-            --nexa-primary-dark: #1d4ed8;
-            --nexa-secondary: #64748b;
-            --nexa-success: #10b981;
-            --nexa-warning: #f59e0b;
-            --nexa-danger: #ef4444;
-            --nexa-info: #06b6d4;
-            --nexa-bg-light: #f8fafc;
-            --nexa-bg-white: #ffffff;
-            --nexa-border: #e2e8f0;
-            --nexa-text-primary: #0f172a;
-            --nexa-text-secondary: #64748b;
-            --nexa-shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-            --nexa-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-            --nexa-shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-            --nexa-shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
-        }
-
         * {
             box-sizing: border-box;
         }
 
         body {
             font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
-            background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+            background: linear-gradient(135deg, var(--nexa-bg-light) 0%, color-mix(in srgb, var(--nexa-bg-light) 60%, var(--nexa-bg-white)) 100%);
             min-height: 100vh;
             color: var(--nexa-text-primary);
         }
@@ -230,17 +212,17 @@ if (!empty($_GET['flash'])) {
 
         .stat-card.orders-pending {
             --stat-color: var(--nexa-warning);
-            --stat-color-dark: #d97706;
+            --stat-color-dark: color-mix(in srgb, var(--nexa-warning) 75%, black);
         }
 
         .stat-card.ship-today {
             --stat-color: var(--nexa-info);
-            --stat-color-dark: #0891b2;
+            --stat-color-dark: color-mix(in srgb, var(--nexa-info) 75%, black);
         }
 
         .stat-card.price-catalogue {
             --stat-color: var(--nexa-success);
-            --stat-color-dark: #059669;
+            --stat-color-dark: color-mix(in srgb, var(--nexa-success) 70%, black);
         }
 
         .stat-card .stat-icon {
@@ -290,7 +272,7 @@ if (!empty($_GET['flash'])) {
         }
 
         .table-card-header {
-            background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+            background: linear-gradient(135deg, var(--nexa-bg-light) 0%, color-mix(in srgb, var(--nexa-bg-light) 75%, var(--nexa-bg-white)) 100%);
             padding: 1.1rem 1.5rem;
             border-bottom: 1px solid var(--nexa-border);
         }
@@ -314,17 +296,17 @@ if (!empty($_GET['flash'])) {
             letter-spacing: 0.05em;
             border-bottom: 2px solid var(--nexa-border);
             padding: 0.75rem;
-            background: #f8fafc;
+            background: var(--nexa-bg-light);
         }
 
         .table tbody td {
             padding: 0.75rem;
             vertical-align: middle;
-            border-bottom: 1px solid #f1f5f9;
+            border-bottom: 1px solid color-mix(in srgb, var(--nexa-border) 70%, transparent);
         }
 
         .table tbody tr:hover {
-            background: #f8fafc;
+            background: var(--nexa-bg-light);
         }
 
         /* Enhanced Aside Cards */
@@ -337,7 +319,7 @@ if (!empty($_GET['flash'])) {
         }
 
         .aside-card-header {
-            background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+            background: linear-gradient(135deg, var(--nexa-bg-light) 0%, color-mix(in srgb, var(--nexa-bg-light) 75%, var(--nexa-bg-white)) 100%);
             padding: 1.1rem;
             border-bottom: 1px solid var(--nexa-border);
         }
@@ -353,13 +335,13 @@ if (!empty($_GET['flash'])) {
 
         .activity-list .list-group-item {
             border: none;
-            border-bottom: 1px solid #f1f5f9;
+            border-bottom: 1px solid color-mix(in srgb, var(--nexa-border) 70%, transparent);
             padding: 0.75rem 1.1rem;
             transition: background-color 0.2s ease;
         }
 
         .activity-list .list-group-item:hover {
-            background: #f8fafc;
+            background: var(--nexa-bg-light);
         }
 
         .activity-list .list-group-item:last-child {
@@ -420,7 +402,7 @@ if (!empty($_GET['flash'])) {
         }
 
         .badge.text-bg-light {
-            background: #f1f5f9 !important;
+            background: var(--nexa-bg-light) !important;
             color: var(--nexa-text-secondary) !important;
             border: 1px solid var(--nexa-border);
         }


### PR DESCRIPTION
## Summary
- add a global `assets/css/root.css` file that captures the Nexa brand palette and common design tokens
- update the landing, authentication, dashboard, and sidebar layouts to link the shared stylesheet and replace hard-coded colors with the brand variables
- align button, background, and accent treatments with the sidebar-derived gradients for consistent styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d64d2949c48328918c0005150b450d