### PR TITLE
Add shared footer to public templates

### DIFF
--- a/component/footer.php
+++ b/component/footer.php
@@ -1,46 +1,49 @@
- 
-<?php
+<?php declare(strict_types=1);
 // component/footer.php — Nexa genel footer
-declare(strict_types=1);
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
+
+if (!defined('NEXA_FOOTER_ASSETS_RENDERED')) {
+    define('NEXA_FOOTER_ASSETS_RENDERED', true);
+    ?>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+
+    <style>
+      footer {
+        background: #fff;
+        border-top: 1px solid #e5e7eb;
+        padding: 1rem 0;
+        font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+        font-size: .9rem;
+        color: #6b7280;
+      }
+      footer .footer-logo {
+        font-family: "Monoton", cursive;
+        font-size: 1.2rem;
+        letter-spacing: 0.1em;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+        margin-right: 1rem;
+        font-weight: 600;
+      }
+      footer a {
+        color: #6b7280;
+        text-decoration: none;
+        transition: color .2s ease;
+      }
+      footer a:hover {
+        color: #374151;
+        text-decoration: underline;
+      }
+    </style>
+    <?php
+}
 ?>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-
-<style>
-  footer {
-    background: #fff;
-    border-top: 1px solid #e5e7eb;
-    padding: 1rem 0;
-    font-family: 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-    font-size: .9rem;
-    color: #6b7280;
-  }
-  footer .footer-logo {
-    font-family: "Monoton", cursive;
-    font-size: 1.2rem;
-    letter-spacing: 0.1em;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin-right: 1rem;
-    font-weight: 600;
-  }
-  footer a {
-    color: #6b7280;
-    text-decoration: none;
-    transition: color .2s ease;
-  }
-  footer a:hover {
-    color: #374151;
-    text-decoration: underline;
-  }
-</style>
-
 <footer class="mt-auto">
   <div class="container-fluid d-flex flex-column flex-md-row justify-content-between align-items-center gap-2 px-3">
     <div class="d-flex align-items-center">

--- a/index.php
+++ b/index.php
@@ -130,6 +130,7 @@ if (!empty($_SESSION['user_id'])) {
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <?php require_once __DIR__ . '/component/footer.php'; ?>
 </body>
 
 </html>

--- a/privacy.php
+++ b/privacy.php
@@ -130,5 +130,6 @@ session_start();
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <?php require_once __DIR__ . '/component/footer.php'; ?>
 </body>
 </html>

--- a/public/auth/login.php
+++ b/public/auth/login.php
@@ -510,6 +510,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </section>
     </main>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <?php require_once __DIR__ . '/../component/footer.php'; ?>
 </body>
 
 </html>

--- a/public/auth/logout.php
+++ b/public/auth/logout.php
@@ -110,6 +110,7 @@ header('Location: ' . $redirectTarget, true, 303);
             </p>
         </noscript>
     </main>
+    <?php require_once __DIR__ . '/../component/footer.php'; ?>
 </body>
 
 </html>

--- a/public/auth/register.php
+++ b/public/auth/register.php
@@ -268,6 +268,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </section>
     </main>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <?php require_once __DIR__ . '/../component/footer.php'; ?>
 </body>
 
 </html>

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -664,5 +664,6 @@ if (!empty($_GET['flash'])) {
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <?php require_once __DIR__ . '/../component/footer.php'; ?>
 </body>
 </html>

--- a/terms.php
+++ b/terms.php
@@ -109,5 +109,6 @@ session_start();
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <?php require_once __DIR__ . '/component/footer.php'; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- require the shared footer in the top-level public templates and authenticated views with the correct relative paths
- guard the footer partial so its fonts and stylesheets are injected only once per request

## Testing
- php -l component/footer.php
- php -l index.php
- php -l privacy.php
- php -l terms.php
- php -l public/auth/login.php
- php -l public/auth/register.php
- php -l public/auth/logout.php
- php -l public/dashboard.php

------
https://chatgpt.com/codex/tasks/task_e_68d653c4ed0c832893216191ebdd3a07