### PR TITLE
Store user roles and permissions in session

### DIFF
--- a/public/api/company/delete.php
+++ b/public/api/company/delete.php
@@ -116,11 +116,27 @@ foreach ($adminFlags as $flag) {
     }
 }
 
-if (!$isPrivileged && isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'admin') {
+if (!$isPrivileged && isset($_SESSION['roles']) && is_array($_SESSION['roles'])) {
+    $roleList = [];
+    foreach ($_SESSION['roles'] as $roleValue) {
+        $roleName = strtolower(trim((string) $roleValue));
+        if ($roleName === '') {
+            continue;
+        }
+        if (!in_array($roleName, $roleList, true)) {
+            $roleList[] = $roleName;
+        }
+    }
+    if (in_array('admin', $roleList, true)) {
+        $isPrivileged = true;
+    }
+}
+
+if (!$isPrivileged && isset($_SESSION['user_role']) && strtolower((string) $_SESSION['user_role']) === 'admin') {
     $isPrivileged = true;
 }
 
-if (!$isPrivileged && isset($_SESSION['role']) && $_SESSION['role'] === 'admin') {
+if (!$isPrivileged && isset($_SESSION['role']) && strtolower((string) $_SESSION['role']) === 'admin') {
     $isPrivileged = true;
 }
 

--- a/public/auth/logout.php
+++ b/public/auth/logout.php
@@ -67,7 +67,16 @@ if (!verifyCsrfToken((string) $csrfTokenFromPost)) {
     exit('Geçersiz CSRF doğrulaması.');
 }
 
-unset($_SESSION['user_id'], $_SESSION['username'], $_SESSION['remember_token']);
+unset(
+    $_SESSION['user_id'],
+    $_SESSION['username'],
+    $_SESSION['remember_token'],
+    $_SESSION['role'],
+    $_SESSION['roles'],
+    $_SESSION['user_role'],
+    $_SESSION['permissions'],
+    $_SESSION['is_admin']
+);
 
 session_unset();
 session_destroy();


### PR DESCRIPTION
## Summary
- load user roles and permissions during login using join queries and store them in the session
- clear the new role and permission session keys on logout
- rely on session-provided role information in the sidebar and company delete API

## Testing
- php -l public/auth/login.php
- php -l public/auth/logout.php
- php -l component/sidebar.php
- php -l public/api/company/delete.php

------
https://chatgpt.com/codex/tasks/task_e_68d6835fa54c8328a4e238e23c6160bb